### PR TITLE
remove dh-systemd from deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: acmeproxy
-Maintainer: Maarten den Braber <m@mdbraber.com> 
-Build-Depends: debhelper (>= 9), wget, dh-systemd, lsb-release
+Maintainer: Maarten den Braber <m@mdbraber.com>
+Build-Depends: debhelper (>= 9), wget, lsb-release
 
 Package: acmeproxy
 Architecture: any


### PR DESCRIPTION
Removes dh-systemd from dependancies, allowing build in newer OS versions.

Closes #14